### PR TITLE
fix: bug login

### DIFF
--- a/src/controller/userLogin.js
+++ b/src/controller/userLogin.js
@@ -13,6 +13,10 @@ const loginUser = async (req, res) => {
       return res.status(404).json({ message: "Invalid email or password" });
     }
 
+    if (!senha || !userWithEmail.rows[0].senha) {
+      return res.status(400).json({ message: "Invalid email or password" });
+    }
+
     const validPassword = await bcrypt.compare(senha, userWithEmail.rows[0].senha);
 
     if (!validPassword) {
@@ -23,7 +27,9 @@ const loginUser = async (req, res) => {
     const { senha: _, ...loggedInUser } = userWithEmail.rows[0];
 
     return res.json({ user: loggedInUser, token });
+
   } catch (error) {
+
     return res.status(500).json({ message: "Unexpected server error!" });
   }
 };

--- a/src/middleware/userRegistrationValidation.js
+++ b/src/middleware/userRegistrationValidation.js
@@ -17,6 +17,7 @@ const userRegistrationValidation = async (req, res, next) => {
     }
     next();
   } catch (error) {
+
     return res.status(500).json({ mensagem: "User validation error." });
   }
 };


### PR DESCRIPTION
A adição da verificação de existência para senha e user 'withEmail.rows[0].senha' antes de chamar 'bcrypt.compare' deve evitar o erro 500 relacionado à ausência da senha e mandar corretamente para o status 400 como esperado.